### PR TITLE
Bugfix/gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ tasks:
   - name: Gitpod config (browser open, workspace bin path)
     init: |
       mkdir -p /workspace/bin
-      cat > /workspace/bin/open.sh <<EOF
+      cat > /workspace/bin/open.sh <<'EOF'
       #!/bin/bash
       exec gp preview --external "$@"
       EOF

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,18 +12,18 @@ tasks:
       sudo update-alternatives --install /usr/bin/www-browser www-browser /workspace/bin/open.sh 100
       echo "export PATH=\"/workspace/bin:\$PATH\"" >> ~/.bashrc
       exit
-  - name: Install conveyor
-    init: |
+  - name: Install conveyor (at startup)
+    command: |
       tmpdir="$(mktemp -d)"
       cd $tmpdir
       wget https://app.conveyordata.com/api/info/cli/location/linux/amd64 -O conveyor_linux_amd64.tar.gz
       tar -zxvf conveyor_linux_amd64.tar.gz
       chmod +x bin/linux/amd64/conveyor
       mkdir -p /workspace/bin
-      sudo install bin/linux/amd64/conveyor /workspace/bin/conveyor
+      sudo install bin/linux/amd64/conveyor /usr/local/bin/conveyor
       cd && rm -r $tmpdir
-    command: exit
-  - name: Install AWS CLI
+      exit
+  - name: Install AWS CLI (during prebuild)
     init: |
       tmpdir="$(mktemp -d)"
       cd $tmpdir

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,13 +38,13 @@ tasks:
 github:
   prebuilds:
     # enable for the default branch (defaults to true)
-    main: false
+    main: true
     # enable for all branches in this repo (defaults to false)
-    branches: false
+    branches: true
     # enable for pull requests coming from this repo (defaults to true)
-    pullRequests: false
+    pullRequests: true
     # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: false
+    pullRequestsFromForks: true
     # add a check to pull requests (defaults to true)
     addCheck: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,26 +1,38 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - name: Uninstall lynx
-    init: sudo apt-get remove lynx -y
-  - name: Install AWS CLI
+  - name: Gitpod config (browser open, workspace bin path)
     init: |
-      curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      unzip awscliv2.zip
-      sudo ./aws/install
-      rm awscliv2.zip
-      rm -rf ./aws
-    command: aws --version
-
-  - name: Install Conveyor CLI
+      mkdir -p /workspace/bin
+      cat > /workspace/bin/open.sh <<EOF
+      #!/bin/bash
+      exec gp preview --external "$@"
+      EOF
+      chmod +x /workspace/bin/open.sh
+    command: |
+      sudo update-alternatives --install /usr/bin/www-browser www-browser /workspace/bin/open.sh 100
+      echo "export PATH=\"/workspace/bin:\$PATH\"" >> ~/.bashrc
+      exit
+  - name: Install conveyor
     init: |
+      tmpdir="$(mktemp -d)"
+      cd $tmpdir
       wget https://app.conveyordata.com/api/info/cli/location/linux/amd64 -O conveyor_linux_amd64.tar.gz
       tar -zxvf conveyor_linux_amd64.tar.gz
       chmod +x bin/linux/amd64/conveyor
-      sudo cp bin/linux/amd64/conveyor /usr/local/bin/conveyor
-      rm conveyor_linux_amd64.tar.gz
-      rm -rf ./bin
-    command: conveyor --version
-
+      mkdir -p /workspace/bin
+      sudo install bin/linux/amd64/conveyor /workspace/bin/conveyor
+      cd && rm -r $tmpdir
+    command: exit
+  - name: Install AWS CLI
+    init: |
+      tmpdir="$(mktemp -d)"
+      cd $tmpdir
+      wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "awscliv2.zip"
+      unzip awscliv2.zip
+      mkdir -p /workspace/aws-cli
+      ./aws/install --install-dir /workspace/aws-cli --bin-dir /workspace/bin
+      cd && rm -r $tmpdir
+    command: exit
 
 # Prebuild settings
 github:


### PR DESCRIPTION
Improved Gitpod configuration

* Eliminates bug where `aws` and `conveyor` are no longer installed after resuming workspaces or prebuilds. The `init` step now only makes changes to the persisted `/workspace` volume.
* Points Gitpod's preferred browser to your actual browser instead of removing `lynx`. `conveyor auth login` will now actually open a tab in your browser! Tested in the browser and VSCode.
* Exits terminals that perform startup tasks, preventing confusion (and the existence of terminals that do not have `/workspace/bin` on `$PATH`).

Question: Why are prebuilds disabled?