### PR TITLE
Split the dags into 2

### DIFF
--- a/basic/coffee_shop_dbt/dags/coffee_shop_dbt.py
+++ b/basic/coffee_shop_dbt/dags/coffee_shop_dbt.py
@@ -1,5 +1,4 @@
 from airflow import DAG
-from conveyor.factories import ConveyorDbtTaskFactory
 from conveyor.operators import ConveyorContainerOperatorV2
 from datetime import timedelta
 from airflow.utils import dates
@@ -36,11 +35,3 @@ marts = ConveyorContainerOperatorV2(
 )
 
 staging >> marts
-
-dag_factory = DAG(
-    "samples_coffee_shop_dbt_factory", default_args=default_args, schedule_interval="@daily", max_active_runs=1,
-)
-
-factory = ConveyorDbtTaskFactory(task_aws_role="conveyor-samples",)
-start, end = factory.add_tasks_to_dag(dag=dag_factory)
-

--- a/basic/coffee_shop_dbt/dags/coffee_shop_dbt_factory.py
+++ b/basic/coffee_shop_dbt/dags/coffee_shop_dbt_factory.py
@@ -1,0 +1,24 @@
+from airflow import DAG
+from conveyor.factories import ConveyorDbtTaskFactory
+from datetime import timedelta
+from airflow.utils import dates
+
+
+default_args = {
+    "owner": "Conveyor",
+    "depends_on_past": False,
+    "start_date": dates.days_ago(2),
+    "email": [],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+}
+
+dag = DAG(
+    "samples_coffee_shop_dbt_factory", default_args=default_args, schedule_interval="@daily", max_active_runs=1,
+)
+
+factory = ConveyorDbtTaskFactory(task_aws_role="conveyor-samples")
+start, end = factory.add_tasks_to_dag(dag=dag)
+


### PR DESCRIPTION
Makes explaining what happens a bit more step by step

- [x] Updated the root `README.md` and sample `README.md`
- [x] Using the `conveyor-samples` aws role
- [x] Airflow dags are prefixed with `samples_`
- [x] No `.conveyor` folder checked-in by mistake 